### PR TITLE
fix for /local/chain/blocks-after method

### DIFF
--- a/src/main/java/io/nem/apps/api/BlockApi.java
+++ b/src/main/java/io/nem/apps/api/BlockApi.java
@@ -7,8 +7,10 @@ import org.nem.core.connect.client.NisApiId;
 import org.nem.core.model.Block;
 import org.nem.core.model.BlockTypes;
 import org.nem.core.model.VerifiableEntity.DeserializationOptions;
+import org.nem.core.serialization.DeserializableList;
 import org.nem.core.serialization.Deserializer;
 
+import io.nem.apps.model.ExplorerBlockViewModel;
 import io.nem.apps.service.NemAppsLibGlobals;
 import net.minidev.json.JSONObject;
 
@@ -37,24 +39,24 @@ public class BlockApi {
 	}
 
 	/**
-	 * Gets the block after given block height.
+	 * Gets no more then 10 block after given block height in form of {@link ExplorerBlockViewModel}.
 	 *
 	 * @param height the height
 	 * @return the block after given block height
 	 * @throws InterruptedException the interrupted exception
 	 * @throws ExecutionException the execution exception
 	 */
-	public static Block getBlockAfterGivenBlockHeight(int height) throws InterruptedException, ExecutionException {
+	public static DeserializableList getBlockAfterGivenBlockHeight(long height) throws InterruptedException, ExecutionException {
 		Deserializer des;
 		JSONObject jsonHeight = new JSONObject();
 		jsonHeight.put("height", height);
 		des = NemAppsLibGlobals.CONNECTOR.postAsync(NemAppsLibGlobals.getNodeEndpoint(), NisApiId.NIS_REST_BLOCK_AFTER_LOCAL,
-				new HttpJsonPostRequest(jsonHeight)).exceptionally(fn -> {
-					fn.printStackTrace();
-					return null;
-				}).get();
-		
-		return new Block(BlockTypes.REGULAR, DeserializationOptions.NON_VERIFIABLE, des);
+													new HttpJsonPostRequest(jsonHeight)).exceptionally(fn -> {
+			fn.printStackTrace();
+			return null;
+		}).get();
+
+		return new DeserializableList<>(des, ExplorerBlockViewModel::new);
 	}
 	
 	/**
@@ -77,26 +79,5 @@ public class BlockApi {
 				}).get();
 		return new Block(blockType, DeserializationOptions.NON_VERIFIABLE, des);
 	}
-	
-	/**
-	 * Gets the block after given block height and blocktype
-	 *
-	 * @param height the height
-	 * @param blockType the block type
-	 * @return the block after given block height
-	 * @throws InterruptedException the interrupted exception
-	 * @throws ExecutionException the execution exception
-	 */
-	public static Block getBlockAfterGivenBlockHeight(int height,int blockType) throws InterruptedException, ExecutionException {
-		Deserializer des;
-		JSONObject jsonHeight = new JSONObject();
-		jsonHeight.put("height", height);
-		des = NemAppsLibGlobals.CONNECTOR.postAsync(NemAppsLibGlobals.getNodeEndpoint(), NisApiId.NIS_REST_BLOCK_AFTER_LOCAL,
-				new HttpJsonPostRequest(jsonHeight)).exceptionally(fn -> {
-					fn.printStackTrace();
-					return null;
-				}).get();
-		
-		return new Block(blockType, DeserializationOptions.NON_VERIFIABLE, des);
-	}
+
 }

--- a/src/main/java/io/nem/apps/model/ExplorerBlockViewModel.java
+++ b/src/main/java/io/nem/apps/model/ExplorerBlockViewModel.java
@@ -1,0 +1,51 @@
+package io.nem.apps.model;
+
+import java.util.List;
+
+import org.nem.core.crypto.Hash;
+import org.nem.core.model.Block;
+import org.nem.core.model.BlockTypes;
+import org.nem.core.model.VerifiableEntity;
+import org.nem.core.serialization.Deserializer;
+
+/**
+ * @author Konstantin Zolotukhin (zolotukhin@softmotions.com)
+ */
+public class ExplorerBlockViewModel {
+
+    private List<ExplorerTransferViewModel> txes;
+
+    private Block block;
+
+    private Hash hash;
+
+    public ExplorerBlockViewModel(Deserializer des) {
+        this.txes = des.readObjectArray("txes", ExplorerTransferViewModel::new);
+        this.block = des.readObject("block", d -> new Block(BlockTypes.REGULAR, VerifiableEntity.DeserializationOptions.NON_VERIFIABLE, d));
+        this.hash = new Hash(des.readBytes("hash"));
+    }
+
+    public List<ExplorerTransferViewModel> getTxes() {
+        return txes;
+    }
+
+    public void setTxes(List<ExplorerTransferViewModel> txes) {
+        this.txes = txes;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public void setBlock(Block block) {
+        this.block = block;
+    }
+
+    public Hash getHash() {
+        return hash;
+    }
+
+    public void setHash(Hash hash) {
+        this.hash = hash;
+    }
+}

--- a/src/main/java/io/nem/apps/model/ExplorerTransferViewModel.java
+++ b/src/main/java/io/nem/apps/model/ExplorerTransferViewModel.java
@@ -1,0 +1,54 @@
+package io.nem.apps.model;
+
+import org.nem.core.crypto.Hash;
+import org.nem.core.model.Transaction;
+import org.nem.core.model.TransactionFactory;
+import org.nem.core.serialization.Deserializer;
+
+/**
+ * @author Konstantin Zolotukhin (zolotukhin@softmotions.com)
+ */
+public class ExplorerTransferViewModel {
+
+    private Transaction transaction;
+
+    private Hash hash;
+
+    private Hash innerHash;
+
+    public ExplorerTransferViewModel(Deserializer des) {
+        this.transaction = des.readObject("tx", TransactionFactory.NON_VERIFIABLE);
+
+        this.hash = new Hash(des.readBytes("hash"));
+
+        byte[] innerHashBytes = des.readOptionalBytes("innerHash");
+
+        if (innerHashBytes != null) {
+            innerHash = new Hash(innerHashBytes);
+        }
+    }
+
+    public Transaction getTransaction() {
+        return transaction;
+    }
+
+    public void setTransaction(Transaction transaction) {
+        this.transaction = transaction;
+    }
+
+    public Hash getHash() {
+        return hash;
+    }
+
+    public void setHash(Hash hash) {
+        this.hash = hash;
+    }
+
+    public Hash getInnerHash() {
+        return innerHash;
+    }
+
+    public void setInnerHash(Hash innerHash) {
+        this.innerHash = innerHash;
+    }
+}

--- a/src/test/java/io/nem/apps/main/BlockApiTest.java
+++ b/src/test/java/io/nem/apps/main/BlockApiTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.Ignore;
 import org.junit.Test;
 import io.nem.apps.api.BlockApi;
+import io.nem.apps.model.ExplorerBlockViewModel;
 
 public class BlockApiTest extends NemAppsUnitTest {
 
@@ -25,7 +26,8 @@ public class BlockApiTest extends NemAppsUnitTest {
 	@Ignore
 	public void testGivenBlockHeight() {
 		try {
-			assertTrue(BlockApi.getBlockAfterGivenBlockHeight(1106194).getTransactions().size() > 0);
+			//Block 1338986 has a transaction on testnet
+			assertTrue( ((ExplorerBlockViewModel) BlockApi.getBlockAfterGivenBlockHeight(1338985).get(0)).getBlock().getTransactions().size() > 0);
 		} catch (InterruptedException | ExecutionException e) {
 			assert(false);
 		}


### PR DESCRIPTION
Actually /local/chain/blocks-after method returns an array of ExplorerBlockViewModel JSON objects rather than a single block. So I added model classes (for some reason they aren't included to nem-core) and fixed a method.